### PR TITLE
Updated Formatter

### DIFF
--- a/lib/simplecov_json_formatter/result_hash_formatter.rb
+++ b/lib/simplecov_json_formatter/result_hash_formatter.rb
@@ -19,8 +19,10 @@ module SimpleCovJSONFormatter
 
     def format_files
       @result.files.each do |source_file|
-        formatted_result[:coverage][source_file.filename] =
-          format_source_file(source_file)
+        formatted_file = format_source_file(source_file)
+
+        formatted_result[:coverage][source_file.filename] = formatted_file
+        minimum_coverage_check_for_file!(source_file, formatted_file)
       end
     end
 
@@ -28,7 +30,10 @@ module SimpleCovJSONFormatter
       @result.groups.each do |name, file_list|
         formatted_result[:groups][name] = {
           lines: {
-            covered_percent: file_list.covered_percent
+            covered_percent: file_list.covered_percent,
+            covered_lines: file_list.covered_lines,
+            missed_lines: file_list.missed_lines,
+            lines_of_code: file_list.lines_of_code
           }
         }
       end
@@ -37,16 +42,33 @@ module SimpleCovJSONFormatter
     def formatted_result
       @formatted_result ||= {
         meta: {
-          simplecov_version: SimpleCov::VERSION
+          simplecov_version: SimpleCov::VERSION, config: config
         },
         coverage: {},
-        groups: {}
+        groups: {},
+        errors: {
+          less_than_minimum_coverage: {}
+        }
       }
     end
 
     def format_source_file(source_file)
       source_file_formatter = SourceFileFormatter.new(source_file)
       source_file_formatter.format
+    end
+
+    def config
+      @config ||= {
+        minimum_coverage: SimpleCov.minimum_coverage[:line],
+        minimum_coverage_by_file: SimpleCov.minimum_coverage_by_file[:line]
+      }
+    end
+
+    def minimum_coverage_check_for_file!(source_file, formatted_file)
+      return nil unless config[:minimum_coverage_by_file]
+      return nil unless formatted_file[:percent] < config[:minimum_coverage_by_file]
+
+      formatted_result[:errors][:less_than_minimum_coverage][source_file.filename] = formatted_file[:percent]
     end
   end
 end

--- a/lib/simplecov_json_formatter/result_hash_formatter.rb
+++ b/lib/simplecov_json_formatter/result_hash_formatter.rb
@@ -12,6 +12,7 @@ module SimpleCovJSONFormatter
     def format
       format_files
       format_groups
+      format_total
 
       formatted_result
     end
@@ -40,6 +41,15 @@ module SimpleCovJSONFormatter
       end
     end
 
+    def format_total
+      formatted_result[:total] = {
+        covered_percent: @result.covered_percent,
+        covered_lines: @result.covered_lines,
+        missed_lines: @result.missed_lines,
+        lines_of_code: @result.total_lines
+      }
+    end
+
     def formatted_result
       @formatted_result ||= {
         meta: {
@@ -47,9 +57,8 @@ module SimpleCovJSONFormatter
         },
         coverage: {},
         groups: {},
-        errors: {
-          less_than_minimum_coverage: {}
-        }
+        errors: { less_than_minimum_coverage: {} },
+        total: {}
       }
     end
 

--- a/lib/simplecov_json_formatter/result_hash_formatter.rb
+++ b/lib/simplecov_json_formatter/result_hash_formatter.rb
@@ -6,6 +6,7 @@ module SimpleCovJSONFormatter
   class ResultHashFormatter
     def initialize(result)
       @result = result
+      @parent_path = "#{Dir.pwd}/"
     end
 
     def format
@@ -68,7 +69,8 @@ module SimpleCovJSONFormatter
       return nil unless config[:minimum_coverage_by_file]
       return nil unless formatted_file[:percent] < config[:minimum_coverage_by_file]
 
-      formatted_result[:errors][:less_than_minimum_coverage][source_file.filename] = formatted_file[:percent]
+      file_name = source_file.filename.delete_prefix(@parent_path)
+      formatted_result[:errors][:less_than_minimum_coverage][file_name] = formatted_file[:percent]
     end
   end
 end

--- a/lib/simplecov_json_formatter/source_file_formatter.rb
+++ b/lib/simplecov_json_formatter/source_file_formatter.rb
@@ -19,7 +19,8 @@ module SimpleCovJSONFormatter
 
     def line_coverage
       @line_coverage ||= {
-        lines: lines
+        lines: lines,
+        percent: percent
       }
     end
 
@@ -45,6 +46,10 @@ module SimpleCovJSONFormatter
       end
 
       branches
+    end
+
+    def percent
+      @source_file.covered_percent
     end
 
     def parse_line(line)

--- a/spec/fixtures/errors.json
+++ b/spec/fixtures/errors.json
@@ -1,20 +1,20 @@
 {
   "meta": {
     "simplecov_version": "0.21.2",
-    "config": { "minimum_coverage": null, "minimum_coverage_by_file": null }
+    "config": { "minimum_coverage": 80, "minimum_coverage_by_file": 80 }
   },
   "coverage": {
     "/STUB_WORKING_DIRECTORY/spec/fixtures/sample.rb": {
       "lines": [
         null,
-        1,
-        1,
-        1,
-        1,
+        0,
+        0,
+        0,
+        0,
         null,
         null,
-        1,
-        1,
+        0,
+        0,
         null,
         null,
         1,
@@ -31,11 +31,11 @@
         "ignored",
         "ignored",
         null
-      ], "percent": 90.0
+      ], "percent": 30.0
     }
   },
   "errors": {
-    "less_than_minimum_coverage": {}
+    "less_than_minimum_coverage": {"/Users/lockstep/Documents/Projects/simplecov-reporter/simplecov_json_formatter/spec/fixtures/sample.rb": 30.0}
   },
   "groups": {}
 }

--- a/spec/fixtures/errors.json
+++ b/spec/fixtures/errors.json
@@ -37,5 +37,6 @@
   "errors": {
     "less_than_minimum_coverage": {"spec/fixtures/sample.rb": 30.0}
   },
+  "total": {"covered_lines": 3, "covered_percent": 30.0, "lines_of_code": 10, "missed_lines": 7},
   "groups": {}
 }

--- a/spec/fixtures/errors.json
+++ b/spec/fixtures/errors.json
@@ -35,7 +35,7 @@
     }
   },
   "errors": {
-    "less_than_minimum_coverage": {"/Users/lockstep/Documents/Projects/simplecov-reporter/simplecov_json_formatter/spec/fixtures/sample.rb": 30.0}
+    "less_than_minimum_coverage": {"spec/fixtures/sample.rb": 30.0}
   },
   "groups": {}
 }

--- a/spec/fixtures/sample.json
+++ b/spec/fixtures/sample.json
@@ -37,5 +37,6 @@
   "errors": {
     "less_than_minimum_coverage": {}
   },
+  "total": {"covered_lines": 9, "covered_percent": 90.0, "lines_of_code": 10, "missed_lines": 1},
   "groups": {}
 }

--- a/spec/fixtures/sample_groups.json
+++ b/spec/fixtures/sample_groups.json
@@ -38,6 +38,7 @@
   "errors": {
     "less_than_minimum_coverage": {}
   },
+  "total": {"covered_lines": 9, "covered_percent": 90.0, "lines_of_code": 10, "missed_lines": 1},
   "groups": {
     "My Group": {
       "lines": {

--- a/spec/fixtures/sample_groups.json
+++ b/spec/fixtures/sample_groups.json
@@ -1,6 +1,7 @@
 {
   "meta": {
-    "simplecov_version": "0.21.2"
+    "simplecov_version": "0.21.2",
+    "config": { "minimum_coverage": null, "minimum_coverage_by_file": null }
   },
   "coverage": {
     "/STUB_WORKING_DIRECTORY/spec/fixtures/sample.rb": {
@@ -30,13 +31,20 @@
         "ignored",
         "ignored",
         null
-      ]
+      ],
+      "percent": 90.0
     }
+  },
+  "errors": {
+    "less_than_minimum_coverage": {}
   },
   "groups": {
     "My Group": {
       "lines": {
-        "covered_percent": 80.0
+        "covered_percent": 90.0,
+        "covered_lines": 90,
+        "missed_lines": 10,
+        "lines_of_code": 100
       }
     }
   }

--- a/spec/fixtures/sample_with_branch.json
+++ b/spec/fixtures/sample_with_branch.json
@@ -1,6 +1,7 @@
 {
   "meta": {
-    "simplecov_version": "0.21.2"
+    "simplecov_version": "0.21.2",
+    "config": { "minimum_coverage": null, "minimum_coverage_by_file": null }
   },
   "coverage": {
     "/STUB_WORKING_DIRECTORY/spec/fixtures/sample.rb": {
@@ -44,8 +45,11 @@
           "end_line": 16,
           "coverage": 1
         }
-      ]
+      ], "percent": 90.0
     }
+  },
+  "errors": {
+    "less_than_minimum_coverage": {}
   },
   "groups": {}
 }

--- a/spec/fixtures/sample_with_branch.json
+++ b/spec/fixtures/sample_with_branch.json
@@ -51,5 +51,6 @@
   "errors": {
     "less_than_minimum_coverage": {}
   },
+  "total": {"covered_lines": 9, "covered_percent": 90.0, "lines_of_code": 10, "missed_lines": 1},
   "groups": {}
 }

--- a/spec/simplecov_json_formatter_spec.rb
+++ b/spec/simplecov_json_formatter_spec.rb
@@ -56,6 +56,27 @@ describe SimpleCov::Formatter::JSONFormatter do
       end
     end
 
+    context 'with errors for minimum coverage' do
+      let(:result) do
+        SimpleCov::Result.new({
+                                source_fixture('sample.rb') => { 'lines' => [
+                                  nil, 0, 0, 0, 0, nil, nil, 0, 0, nil, nil,
+                                  1, 1, 0, nil, 1, nil, nil, nil, nil, 1, 0, nil, nil, nil
+                                ] }
+                              })
+      end
+
+      before do
+        allow(SimpleCov).to receive(:minimum_coverage).and_return({ line: 80 })
+        allow(SimpleCov).to receive(:minimum_coverage_by_file).and_return({ line: 80 })
+      end
+
+      it 'displays errors for less than minimum coverage by file' do
+        subject.format(result)
+        expect(json_ouput).to eq(json_result('errors'))
+      end
+    end
+
     context 'with groups' do
       let(:result) do
         res = SimpleCov::Result.new({
@@ -67,7 +88,10 @@ describe SimpleCov::Formatter::JSONFormatter do
 
         # right now SimpleCov works mostly on global state, hence setting the groups that way
         # would be global state --> Mocking is better here
-        allow(res).to receive_messages(groups: { 'My Group' => double('File List', covered_percent: 80.0) })
+        allow(res).to receive_messages(groups: { 'My Group' => double('File List', covered_percent: 90.0,
+                                                                                   covered_lines: 90,
+                                                                                   missed_lines: 10,
+                                                                                   lines_of_code: 100) })
         res
       end
 


### PR DESCRIPTION
I was making a Github Actions project for working with SimpleCov. Turns out this being the recommended gem by SimpleCov, didn't have some functionalities I was thinking of adding support for. So added it here in this PR. If you have any thoughts or suggestions do let me know 😄 

What's Changed:
- [x] Minimum Coverage Check for file. If fails, the file name and the percent_covered is collected in errors.
- [x] Groups now contain more information such as covered_lines, missed_lines and total_lines.
- [x] Also returns config details like minimum_coverage and minimum_coverage_by_file. 
- [x] Total metrics as default (even when groups are not available).